### PR TITLE
Fix failing unit test

### DIFF
--- a/src/test/java/dev/yeff/orbital/tests/ecs/GameObjectTests.java
+++ b/src/test/java/dev/yeff/orbital/tests/ecs/GameObjectTests.java
@@ -18,6 +18,7 @@ import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import java.util.Optional;
 
 @DisplayName("test game objects creation and adding components to game objects")
 public class GameObjectTests implements WithAssertions {
@@ -66,7 +67,7 @@ public class GameObjectTests implements WithAssertions {
         assertThat(object.hasComponent(RenderShapeComponent.class)).isTrue();
         assertThat(object.getComponent(RenderShapeComponent.class))
                 .extracting("shape", "color")
-                .contains(Shapes.CIRCLE, Color.RED);
+                .contains(Shapes.CIRCLE, Optional.of(Color.RED));
     }
 
     @DisplayName("create game object with text component using builder")


### PR DESCRIPTION
The following test was failing: https://github.com/OrbitalEngine/Orbital/blob/eb25bda2dfa3d1cb7bcb3a4f9c15471b125ba701/src/test/java/dev/yeff/orbital/tests/ecs/GameObjectTests.java#L61

I noticed the `testCreateGameObject_withShape_usingBuilder()` test failed because in the `RenderShapeComponent` class the type of color is an `Optional`. So, when the assert checked if the `Color.RED` was there, it didn't find it. To fix it, the `Color.RED` is transformed in an `Optional`.